### PR TITLE
Fix an issue with the fastify/node server crash

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,7 +44,7 @@ async function encrypt(key, data){
  * @returns { Promise<string> }
  */
 async function decrypt(key, data){
-    if(!data || data.length < 32) // iv in hex format will always have 32 characters
+    if(!data || data.length < 32 || data.length % 2 !== 0) // iv in hex format will always have 32 characters
         throw new Error('Invalid data');
 
     const iv = Buffer.from(data.substring(0, 32), 'hex');

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -20,6 +20,7 @@ function decryption(tap){
     tap.rejects(() => decrypt(key, ''), `decrypt('') empty string throws`);
     tap.rejects(() => decrypt(key, '1'.repeat(31)), `decrypt('') w/ string length < 32 throws`);
     tap.rejects(() => decrypt(key, '1'.repeat(50)), `decrypt('') w/ invalid data throws`);
+    tap.rejects(() => decrypt(key, '1'.repeat(51)), `decrypt('') w/ invalid data throws`);
     tap.done();
 }
 


### PR DESCRIPTION
An invalid hexadecimal string in a data parameter in a `decrypt` method crashes the server process.